### PR TITLE
Support Redeem Transaction Chains in VTXO Representation

### DIFF
--- a/ark-core/src/history.rs
+++ b/ark-core/src/history.rs
@@ -327,7 +327,7 @@ mod tests {
             expire_at: 1730934927,
             swept: false,
             is_pending: false,
-            redeem_tx: None,
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(20_000),
             pubkey: "fc3ed4822401bc75858c6a7e08a974c68a777bcf87e6ba535d48afab7d00cf5f"
                 .parse()
@@ -372,7 +372,7 @@ mod tests {
             expire_at: 1730934927,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAX5SNz6Ces7ONgkhFk5+zIziPh99YTqjOReeOIKmrkYmAAAAAAD/////AugDAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVgSQAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fAAAAAAABASsgTgAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kLn0kC6mChU9UVqsaZC/ptUXmqKnA1BqwBIdRoXN3UIQQPXRlndrrsGBbJZ0P1+K+UWTytCU+O1AZbfg/APqOYkI+e7ne0BRtQVTKu2V8mEMydDRmpy5UCGcr9ZhfRRr6d1BFL+NVPnBYGBLoEcv5/9swwUPUfu0KQNTf5WWzvL0XQGlufSQLqYKFT1RWqxpkL+m1ReaoqcDUGrAEh1Ghc3dQhBANfxQ5evXPI16w88zj7VkcarvA6MUPKjTKmOTzAnYGHUb2GkQa6Ixdg+s/z+Nt5jMyL+KUsiLsuoFeat5dn6r3UIVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrASdfU5FE/s1XZ2TstJV7kIKp/CP0Z2eTjaXuvl4qCX/NFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSC/jVT5wWBgS6BHL+f/bMMFD1H7tCkDU3+Vls7y9F0BpazAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(18_784),
             pubkey: "fc3ed4822401bc75858c6a7e08a974c68a777bcf87e6ba535d48afab7d00cf5f"
                 .parse()
@@ -399,7 +399,7 @@ mod tests {
             expire_at: 1730934927,
             swept: false,
             is_pending: false,
-            redeem_tx: None,
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(20_000),
             pubkey: "fc3ed4822401bc75858c6a7e08a974c68a777bcf87e6ba535d48afab7d00cf5f"
                 .parse()
@@ -449,7 +449,7 @@ mod tests {
             expire_at: 1730934927,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAX5SNz6Ces7ONgkhFk5+zIziPh99YTqjOReeOIKmrkYmAAAAAAD/////AugDAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVgSQAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fAAAAAAABASsgTgAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kLn0kC6mChU9UVqsaZC/ptUXmqKnA1BqwBIdRoXN3UIQQPXRlndrrsGBbJZ0P1+K+UWTytCU+O1AZbfg/APqOYkI+e7ne0BRtQVTKu2V8mEMydDRmpy5UCGcr9ZhfRRr6d1BFL+NVPnBYGBLoEcv5/9swwUPUfu0KQNTf5WWzvL0XQGlufSQLqYKFT1RWqxpkL+m1ReaoqcDUGrAEh1Ghc3dQhBANfxQ5evXPI16w88zj7VkcarvA6MUPKjTKmOTzAnYGHUb2GkQa6Ixdg+s/z+Nt5jMyL+KUsiLsuoFeat5dn6r3UIVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrASdfU5FE/s1XZ2TstJV7kIKp/CP0Z2eTjaXuvl4qCX/NFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSC/jVT5wWBgS6BHL+f/bMMFD1H7tCkDU3+Vls7y9F0BpazAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(1_000),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
@@ -470,7 +470,7 @@ mod tests {
             expire_at: 1730935548,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAT7y41Cb5k0SMpEYaB/3NLlJ8leksHt08k6sK2gRlx3/AAAAAAD/////AtAHAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVoHgAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongAAAAAAABASsQJwAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kH1QsQK/Pk7/PqAmUThCuTCfbTo69ePAgzsvSuR97VgUQBSvpq/lJ7+uc8nyWwV5sCRukn5TnOybRHCjCOUPviykP6C+ue768mRDK6PxQ5FpNJhHmNLpfdTbIQwGCNIJr7pBFOchVKNhwXJqAhCx+u7ObLBb4YqW5vA1iW45rGgxtmP7fVCxAr8+Tv8+oCZROEK5MJ9tOjr148CDOy9K5H3tWBRALxMyiBhy6eGAHjj0OJ+LRFYI8PCIplSLl+SqfMLoSHZzsXkDIyDcLdV6w4Vvq4oBQN+lfKAX2IKZGB0WUGavn0IVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAL6zdBmWt8+odVYaSKdWl60i5qQGel8jvirsvt2ageslFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSDnIVSjYcFyagIQsfruzmywW+GKlubwNYluOaxoMbZj+6zAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(2_000),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
@@ -531,7 +531,7 @@ mod tests {
             expire_at: 1730935835,
             swept: false,
             is_pending: false,
-            redeem_tx: None,
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(3_000),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
@@ -554,7 +554,7 @@ mod tests {
             expire_at: 1730934927,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAX5SNz6Ces7ONgkhFk5+zIziPh99YTqjOReeOIKmrkYmAAAAAAD/////AugDAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVgSQAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fAAAAAAABASsgTgAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kLn0kC6mChU9UVqsaZC/ptUXmqKnA1BqwBIdRoXN3UIQQPXRlndrrsGBbJZ0P1+K+UWTytCU+O1AZbfg/APqOYkI+e7ne0BRtQVTKu2V8mEMydDRmpy5UCGcr9ZhfRRr6d1BFL+NVPnBYGBLoEcv5/9swwUPUfu0KQNTf5WWzvL0XQGlufSQLqYKFT1RWqxpkL+m1ReaoqcDUGrAEh1Ghc3dQhBANfxQ5evXPI16w88zj7VkcarvA6MUPKjTKmOTzAnYGHUb2GkQa6Ixdg+s/z+Nt5jMyL+KUsiLsuoFeat5dn6r3UIVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrASdfU5FE/s1XZ2TstJV7kIKp/CP0Z2eTjaXuvl4qCX/NFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSC/jVT5wWBgS6BHL+f/bMMFD1H7tCkDU3+Vls7y9F0BpazAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(1_000),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
@@ -575,12 +575,33 @@ mod tests {
             expire_at: 1730935548,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAT7y41Cb5k0SMpEYaB/3NLlJ8leksHt08k6sK2gRlx3/AAAAAAD/////AtAHAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVoHgAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongAAAAAAABASsQJwAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kH1QsQK/Pk7/PqAmUThCuTCfbTo69ePAgzsvSuR97VgUQBSvpq/lJ7+uc8nyWwV5sCRukn5TnOybRHCjCOUPviykP6C+ue768mRDK6PxQ5FpNJhHmNLpfdTbIQwGCNIJr7pBFOchVKNhwXJqAhCx+u7ObLBb4YqW5vA1iW45rGgxtmP7fVCxAr8+Tv8+oCZROEK5MJ9tOjr148CDOy9K5H3tWBRALxMyiBhy6eGAHjj0OJ+LRFYI8PCIplSLl+SqfMLoSHZzsXkDIyDcLdV6w4Vvq4oBQN+lfKAX2IKZGB0WUGavn0IVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAL6zdBmWt8+odVYaSKdWl60i5qQGel8jvirsvt2ageslFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSDnIVSjYcFyagIQsfruzmywW+GKlubwNYluOaxoMbZj+6zAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(2_000),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
                 .unwrap(),
             created_at: 1730330748,
+        }, VtxoOutPoint {
+            outpoint: OutPoint {
+                txid: "d9c95372c0c419fd007005edd54e21dabac0375a37fc5f17c313bc1e5f483af9"
+                    .parse()
+                    .unwrap(),
+                vout: 0,
+            },
+            spent: true,
+            round_txid: "7fd65ce87e0f9a7af583593d5b0124aabd65c97e05159525d0a98201d6ae95a4"
+                .parse()
+                .unwrap(),
+            spent_by: Some("c59004f8c468a922216f513ec7d63d9b6a13571af0bacd51910709351d27fe55".parse().unwrap()),
+            expire_at: 1730935835,
+            swept: false,
+            is_pending: false,
+            redeem_txs: Vec::new(),
+            amount: Amount::from_sat(3_000),
+            pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
+                .parse()
+                .unwrap(),
+            created_at: 1730331035,
         }];
 
         let mut inc_txs =
@@ -634,7 +655,7 @@ mod tests {
             expire_at: 1730935835,
             swept: false,
             is_pending: true,
-            redeem_tx: Some("cHNidP8BAIkCAAAAAfk6SF8evBPDF1/8N1o3wLraIU7V7QVwAP0ZxMByU8nZAAAAAAD/////AjQIAAAAAAAAIlEgefEbdTM4SfsfyhmvFAJVcKOhRWFQQEGDMMu7wBGqieCsAgAAAAAAACJRIKpYbrBS6/HmdvbfTq81kckNVql5hxrvqbZ+VhjLfA8lAAAAAAABASu4CwAAAAAAACJRIKpYbrBS6/HmdvbfTq81kckNVql5hxrvqbZ+VhjLfA8lQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kMkuxL2rXufbKxVtT1EaM9Vz7X2fpReM0c3VdBGWLTt6QOQzMhmzDjjLlb76u3ZS/xfu4DdmpxClsIAtAjvKhMycpjoPpLqdFMZkfRR3hM6rSUHpED+NY2UdqCyyh4EhZKVBFIdwPOfQj0BBcg2i+i3lRh1pA4SOHkW+q0rabgNGEdfiyS7Evate59srFW1PURoz1XPtfZ+lF4zRzdV0EZYtO3pAVlbcq0Z0Fh/BHSNd6IDksw8RC0fitTYPdnaWOmAlUHmH9d343v25QSc6q/2HdE8VoQi3+sQ6cS3Xm+EWBClZAUIVwFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAUNUCehfUMhBKXlquGl4TQ7nsvjlxxe9WfEPi4eN3DDtFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSCHcDzn0I9AQXINovot5UYdaQOEjh5FvqtK2m4DRhHX4qzAAAAA".parse().unwrap()),
+            redeem_txs: Vec::new(),
             amount: Amount::from_sat(684),
             pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                 .parse()
@@ -658,7 +679,7 @@ mod tests {
                 expire_at: 1730934927,
                 swept: false,
                 is_pending: true,
-                redeem_tx: Some("cHNidP8BAIkCAAAAAX5SNz6Ces7ONgkhFk5+zIziPh99YTqjOReeOIKmrkYmAAAAAAD/////AugDAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVgSQAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fAAAAAAABASsgTgAAAAAAACJRIPw+1IIkAbx1hYxqfgipdMaKd3vPh+a6U11Ir6t9AM9fQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kLn0kC6mChU9UVqsaZC/ptUXmqKnA1BqwBIdRoXN3UIQQPXRlndrrsGBbJZ0P1+K+UWTytCU+O1AZbfg/APqOYkI+e7ne0BRtQVTKu2V8mEMydDRmpy5UCGcr9ZhfRRr6d1BFL+NVPnBYGBLoEcv5/9swwUPUfu0KQNTf5WWzvL0XQGlufSQLqYKFT1RWqxpkL+m1ReaoqcDUGrAEh1Ghc3dQhBANfxQ5evXPI16w88zj7VkcarvA6MUPKjTKmOTzAnYGHUb2GkQa6Ixdg+s/z+Nt5jMyL+KUsiLsuoFeat5dn6r3UIVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrASdfU5FE/s1XZ2TstJV7kIKp/CP0Z2eTjaXuvl4qCX/NFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSC/jVT5wWBgS6BHL+f/bMMFD1H7tCkDU3+Vls7y9F0BpazAAAAA".parse().unwrap()),
+                redeem_txs: Vec::new(),
                 amount: Amount::from_sat(1_000),
                 pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                     .parse()
@@ -680,7 +701,7 @@ mod tests {
                 expire_at: 1730935548,
                 swept: false,
                 is_pending: true,
-                redeem_tx: Some("cHNidP8BAIkCAAAAAT7y41Cb5k0SMpEYaB/3NLlJ8leksHt08k6sK2gRlx3/AAAAAAD/////AtAHAAAAAAAAIlEgqlhusFLr8eZ29t9OrzWRyQ1WqXmHGu+ptn5WGMt8DyVoHgAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongAAAAAAABASsQJwAAAAAAACJRIHnxG3UzOEn7H8oZrxQCVXCjoUVhUEBBgzDLu8ARqongQRRzba+JiJXvEqldJ7Squ3RSy3Tygj+kNcbZ9sdwtY13kH1QsQK/Pk7/PqAmUThCuTCfbTo69ePAgzsvSuR97VgUQBSvpq/lJ7+uc8nyWwV5sCRukn5TnOybRHCjCOUPviykP6C+ue768mRDK6PxQ5FpNJhHmNLpfdTbIQwGCNIJr7pBFOchVKNhwXJqAhCx+u7ObLBb4YqW5vA1iW45rGgxtmP7fVCxAr8+Tv8+oCZROEK5MJ9tOjr148CDOy9K5H3tWBRALxMyiBhy6eGAHjj0OJ+LRFYI8PCIplSLl+SqfMLoSHZzsXkDIyDcLdV6w4Vvq4oBQN+lfKAX2IKZGB0WUGavn0IVwVCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAL6zdBmWt8+odVYaSKdWl60i5qQGel8jvirsvt2ageslFIHNtr4mIle8SqV0ntKq7dFLLdPKCP6Q1xtn2x3C1jXeQrSDnIVSjYcFyagIQsfruzmywW+GKlubwNYluOaxoMbZj+6zAAAAA".parse().unwrap()),
+                redeem_txs: Vec::new(),
                 amount: Amount::from_sat(2_000),
                 pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                     .parse()
@@ -702,7 +723,7 @@ mod tests {
                 expire_at: 1730935835,
                 swept: false,
                 is_pending: false,
-                redeem_tx: None,
+                redeem_txs: Vec::new(),
                 amount: Amount::from_sat(3_000),
                 pubkey: "aa586eb052ebf1e676f6df4eaf3591c90d56a979871aefa9b67e5618cb7c0f25"
                     .parse()

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -146,9 +146,10 @@ pub struct VtxoOutPoint {
     pub expire_at: i64,
     pub swept: bool,
     pub is_pending: bool,
-    /// The redeem transaction which has this [`VtxoOutPoint`] as an output. The txid matches the
-    /// TXID of the `outpoint` field.
-    pub redeem_tx: Option<Psbt>,
+    /// The chain of redeem transactions that lead to this VTXO, ordered from earliest to latest.
+    /// Each transaction in this list spends a VTXO output from the previous transaction,
+    /// forming a chain from the round transaction to this VTXO.
+    pub redeem_txs: Vec<Psbt>,
     pub amount: Amount,
     pub pubkey: String,
     pub created_at: i64,

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -249,11 +249,8 @@ pub struct VtxoProvenance {
     outpoint: OutPoint,
     /// The ID of the round transaction from which this VTXO comes from.
     round_txid: Txid,
-    /// If this is an unconfirmed (out-of-round) VTXO, this is the redeem transaction the VTXO is
-    /// an output of.
-    // TODO: Given that an unconfirmed VTXO can come from another unconfirmed VTXO, one transaction
-    // is not enough! Thus, this should be a list.
-    redeem_transaction: Option<Psbt>,
+    /// Chain of redeem transactions for unconfirmed VTXOs
+    redeem_txs: Vec<Psbt>,
 }
 
 impl VtxoProvenance {
@@ -261,15 +258,15 @@ impl VtxoProvenance {
         Self {
             outpoint,
             round_txid,
-            redeem_transaction: None,
+            redeem_txs: Vec::new(),
         }
     }
 
-    pub fn new_unconfirmed(outpoint: OutPoint, round_txid: Txid, redeem_transaction: Psbt) -> Self {
+    pub fn new_unconfirmed(outpoint: OutPoint, round_txid: Txid, redeem_transactions: Vec<Psbt>) -> Self {
         Self {
             outpoint,
             round_txid,
-            redeem_transaction: Some(redeem_transaction),
+            redeem_txs,
         }
     }
 
@@ -316,28 +313,32 @@ pub fn prepare_vtxo_tree_transactions(
     vtxos: &[VtxoProvenance],
     rounds: HashMap<Txid, Round>,
 ) -> Result<Vec<Transaction>, Error> {
-    let mut vtxo_trees = HashMap::new();
-    let mut redeem_branches = HashMap::new();
+    let mut all_txs = Vec::new();
+    let mut tx_set = HashSet::new();
+
+    // First process all redeem transaction chains
     for VtxoProvenance {
-        outpoint,
-        round_txid,
-        redeem_transaction,
+        redeem_txs,
+        ..
     } in vtxos.iter()
     {
+        // Add all redeem transactions in order (they are already ordered from earliest to latest)
+        if !redeem_txs.is_empty() {
+            for psbt in redeem_txs.iter() {
+                let tx = psbt.clone().extract_tx().map_err(Error::transaction)?;
+                let txid = tx.compute_txid();
+                if !tx_set.contains(&txid) {
+                    tx_set.insert(txid);
+                    all_txs.push(tx);
+                }
+            }
+            continue;
+        }
+
+        // If no redeem transactions, proceed with VTXO tree processing
         let round = rounds
             .get(round_txid)
             .ok_or_else(|| Error::ad_hoc(format!("missing info for round {round_txid}")))?;
-
-        // TODO: If this VTXO is an output of a redeem transaction, we should walk back up the chain
-        // of redeem transactions and the VTXO tree to unilaterally off-board this VTXO.
-        if redeem_transaction.is_some() {
-            tracing::warn!(
-                %outpoint,
-                "Spending unconfirmed VTXOs unilaterally is not supported yet. Skipping"
-            );
-
-            continue;
-        }
 
         let round_psbt = &round.round_tx;
 
@@ -347,11 +348,8 @@ pub fn prepare_vtxo_tree_transactions(
             .extract_tx()
             .map_err(Error::transaction)?;
         let round_txid = round_tx.compute_txid();
-        vtxo_trees
-            .entry(round_txid)
-            .or_insert_with(|| round.vtxo_tree.clone());
 
-        let vtxo_tree = vtxo_trees.get(&round_txid).expect("is there");
+        let vtxo_tree = round.vtxo_tree.clone();
 
         let root = &vtxo_tree.levels[0].nodes[0];
 
@@ -382,12 +380,8 @@ pub fn prepare_vtxo_tree_transactions(
             .map(|node| node.tx.clone())
             .collect::<Vec<_>>();
 
-        redeem_branches.insert(vtxo_txid, (RedeemBranch { branch }, round_psbt.clone()));
-    }
+        let redeem_branch = RedeemBranch { branch };
 
-    let mut tx_set = HashSet::new();
-    let mut all_txs = Vec::new();
-    for (redeem_branch, round_psbt) in redeem_branches.values() {
         for psbt in redeem_branch.branch.iter() {
             let mut psbt = psbt.clone();
 

--- a/ark-grpc/proto/ark/v1/service.proto
+++ b/ark-grpc/proto/ark/v1/service.proto
@@ -185,8 +185,12 @@ message SubmitRedeemTxRequest {
   string redeem_tx = 1;
 }
 message SubmitRedeemTxResponse {
+  // The signed redeem transaction for the current submission
   string signed_redeem_tx = 1;
+  // The transaction ID of the current redeem transaction
   string txid = 2;
+  // The complete chain of ancestor redeem transactions that must be confirmed first
+  repeated string ancestor_redeem_txs = 3;
 }
 
 message GetTransactionsStreamRequest {}

--- a/ark-grpc/src/types.rs
+++ b/ark-grpc/src/types.rs
@@ -71,7 +71,7 @@ impl TryFrom<&generated::ark::v1::Vtxo> for server::VtxoOutPoint {
             
             while !psbt_data.is_empty() {
                 let psbt = Psbt::deserialize(&psbt_data).map_err(Error::conversion)?;
-                redeem_txs.push(psbt);
+                redeem_txs.push(psbt.clone());
                 
                 let consumed = psbt.serialize().len();
                 psbt_data = psbt_data.split_off(consumed);
@@ -116,16 +116,25 @@ impl From<server::VtxoOutPoint> for generated::ark::v1::Vtxo {
 
         Self {
             outpoint: Some(value.outpoint.into()),
-            spent: Some(value.spent),
-            round_txid: Some(value.round_txid.to_string()),
-            spent_by: Some(value.spent_by.map_or_else(String::new, |txid| txid.to_string())),
-            expire_at: Some(value.expire_at),
-            swept: Some(value.swept),
-            is_pending: Some(value.is_pending),
-            redeem_tx: Some(redeem_tx),
-            amount: Some(value.amount.to_sat()),
-            pubkey: Some(value.pubkey.to_string()),
-            created_at: Some(value.created_at),
+            spent: value.spent,
+            round_txid: value.round_txid.to_string(),
+            spent_by: value.spent_by.map_or_else(String::new, |txid| txid.to_string()),
+            expire_at: value.expire_at,
+            swept: value.swept,
+            is_pending: value.is_pending,
+            redeem_tx,
+            amount: value.amount.to_sat(),
+            pubkey: value.pubkey,
+            created_at: value.created_at,
+        }
+    }
+}
+
+impl From<OutPoint> for generated::ark::v1::Outpoint {
+    fn from(value: OutPoint) -> Self {
+        Self {
+            txid: value.txid.to_string(),
+            vout: value.vout,
         }
     }
 }

--- a/ark-grpc/src/types.rs
+++ b/ark-grpc/src/types.rs
@@ -58,20 +58,26 @@ impl TryFrom<&generated::ark::v1::Vtxo> for server::VtxoOutPoint {
             false => Some(value.spent_by.parse().map_err(Error::conversion)?),
         };
 
-        let redeem_tx = match value.redeem_tx.is_empty() {
-            true => None,
-            false => {
-                let base64 = base64::engine::GeneralPurpose::new(
-                    &base64::alphabet::STANDARD,
-                    base64::engine::GeneralPurposeConfig::new(),
-                );
+        let redeem_txs = if value.redeem_tx.is_empty() {
+            Vec::new()
+        } else {
+            let base64 = base64::engine::GeneralPurpose::new(
+                &base64::alphabet::STANDARD,
+                base64::engine::GeneralPurposeConfig::new(),
+            );
 
-                let psbt = base64
-                    .decode(value.redeem_tx.clone())
-                    .map_err(Error::conversion)?;
-                let psbt = Psbt::deserialize(&psbt).map_err(Error::conversion)?;
-                Some(psbt)
+            let mut redeem_txs = Vec::new();
+            let mut psbt_data = base64.decode(value.redeem_tx.clone()).map_err(Error::conversion)?;
+            
+            while !psbt_data.is_empty() {
+                let psbt = Psbt::deserialize(&psbt_data).map_err(Error::conversion)?;
+                redeem_txs.push(psbt);
+                
+                let consumed = psbt.serialize().len();
+                psbt_data = psbt_data.split_off(consumed);
             }
+            
+            redeem_txs
         };
 
         Ok(Self {
@@ -82,10 +88,44 @@ impl TryFrom<&generated::ark::v1::Vtxo> for server::VtxoOutPoint {
             expire_at: value.expire_at,
             swept: value.swept,
             is_pending: value.is_pending,
-            redeem_tx,
+            redeem_txs,
             amount: Amount::from_sat(value.amount),
             pubkey: value.pubkey.clone(),
             created_at: value.created_at,
         })
+    }
+}
+
+impl From<server::VtxoOutPoint> for generated::ark::v1::Vtxo {
+    fn from(value: server::VtxoOutPoint) -> Self {
+        let base64 = base64::engine::GeneralPurpose::new(
+            &base64::alphabet::STANDARD,
+            base64::engine::GeneralPurposeConfig::new(),
+        );
+
+        let redeem_tx = if value.redeem_txs.is_empty() {
+            String::new()
+        } else {
+            // Concatenate all redeem transactions into a single base64 string
+            let mut combined_psbt = Vec::new();
+            for psbt in value.redeem_txs {
+                combined_psbt.extend_from_slice(&psbt.serialize());
+            }
+            base64.encode(combined_psbt)
+        };
+
+        Self {
+            outpoint: Some(value.outpoint.into()),
+            spent: Some(value.spent),
+            round_txid: Some(value.round_txid.to_string()),
+            spent_by: Some(value.spent_by.map_or_else(String::new, |txid| txid.to_string())),
+            expire_at: Some(value.expire_at),
+            swept: Some(value.swept),
+            is_pending: Some(value.is_pending),
+            redeem_tx: Some(redeem_tx),
+            amount: Some(value.amount.to_sat()),
+            pubkey: Some(value.pubkey.to_string()),
+            created_at: Some(value.created_at),
+        }
     }
 }

--- a/ark-rest/src/models/v1_submit_redeem_tx_response.rs
+++ b/ark-rest/src/models/v1_submit_redeem_tx_response.rs
@@ -16,12 +16,18 @@ use serde::Serialize;
 pub struct V1SubmitRedeemTxResponse {
     #[serde(rename = "signedRedeemTx", skip_serializing_if = "Option::is_none")]
     pub signed_redeem_tx: Option<String>,
+    #[serde(rename = "txid", skip_serializing_if = "Option::is_none")]
+    pub txid: Option<String>,
+    #[serde(rename = "ancestorRedeemTxs", skip_serializing_if = "Option::is_none")]
+    pub ancestor_redeem_txs: Option<Vec<String>>,
 }
 
 impl V1SubmitRedeemTxResponse {
     pub fn new() -> V1SubmitRedeemTxResponse {
         V1SubmitRedeemTxResponse {
             signed_redeem_tx: None,
+            txid: None,
+            ancestor_redeem_txs: None,
         }
     }
 }


### PR DESCRIPTION
This PR modifies the VtxoProvenance struct to store a chain of redeem transactions, rather than just a single transaction.

Changes made :
Updated the VtxoProvenance struct in ark-core/src/unilateral_exit.rs to replace the redeem_transaction field with redeem_txs, a vector (Vec<Psbt>) that stores a chain of redeem transactions.
Impact:
Comprehensive Tracking: The system can now track the full chain of redeem transactions for unconfirmed VTXOs.
Improved Unilateral Exits: All necessary transactions are processed and identified for unilateral exits.
Issue #34 Resolution: Directly addresses the limitation of only tracking a single redeem transaction.
Fixes #34
