### PR TITLE
fix: wasm build on osx

### DIFF
--- a/ark-rust-secp256k1-zkp/ark-secp256k1-zkp-sys/depend/secp256k1/src/modules/extrakeys/hsort_impl.h
+++ b/ark-rust-secp256k1-zkp/ark-secp256k1-zkp-sys/depend/secp256k1/src/modules/extrakeys/hsort_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_HSORT_IMPL_H_
 #define SECP256K1_HSORT_IMPL_H_
 
+#include <string.h>
 #include "hsort.h"
 
 /* An array is a heap when, for all non-zero indexes i, the element at index i
@@ -23,11 +24,24 @@ static SECP256K1_INLINE size_t child2(size_t i) {
     return child1(i)+1;
 }
 
+static inline void* my_memmove(void* dest, const void* src, size_t n) {
+    unsigned char* d = (unsigned char*)dest;
+    const unsigned char* s = (const unsigned char*)src;
+    if (d < s) {
+        while (n--) *d++ = *s++;
+    } else {
+        d += n;
+        s += n;
+        while (n--) *--d = *--s;
+    }
+    return dest;
+}
+
 static SECP256K1_INLINE void heap_swap64(unsigned char *a, size_t i, size_t j, size_t stride) {
     unsigned char tmp[64];
     VERIFY_CHECK(stride <= 64);
     memcpy(tmp, a + i*stride, stride);
-    memmove(a + i*stride, a + j*stride, stride);
+    my_memmove(a + i*stride, a + j*stride, stride);
     memcpy(a + j*stride, tmp, stride);
 }
 

--- a/ark-rust-secp256k1-zkp/ark-secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/adaptor_impl.h
+++ b/ark-rust-secp256k1-zkp/ark-secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/adaptor_impl.h
@@ -63,7 +63,7 @@ int rustsecp256k1zkp_v0_8_0_musig_adapt(const rustsecp256k1zkp_v0_8_0_context* c
 
     rustsecp256k1zkp_v0_8_0_scalar_add(&s, &s, &t);
     rustsecp256k1zkp_v0_8_0_scalar_get_b32(&sig64[32], &s);
-    memmove(sig64, pre_sig64, 32);
+    my_memmove(sig64, pre_sig64, 32);
     rustsecp256k1zkp_v0_8_0_scalar_clear(&t);
     return ret;
 }


### PR DESCRIPTION
When compiling the secp256k1-zkp library for the wasm32-unknown-unknown target on macOS, the build fails with undeclared function errors for 'memmove'. This occurs because the standard C library headers are not correctly included or recognized when cross-compiling to WebAssembly on macOS systems.

We can't seem to rely on the system header <string.h>, hence, we add a custom implementation of memmove directly in the relevant files.

This fix is specifically needed on macOS due to differences in how the clang compiler and the build system handle header includes when targeting WebAssembly.

resolves #48 

# NOTE: I'm not sure this is the way to go!