### PR TITLE
Use high level API to generate nonces

### DIFF
--- a/ark-client/src/round.rs
+++ b/ark-client/src/round.rs
@@ -350,10 +350,14 @@ where
                         let mut our_nonce_tree_map = HashMap::new();
                         for own_cosigner_kp in own_cosigner_kps {
                             let own_cosigner_pk = own_cosigner_kp.public_key();
-                            let nonce_tree =
-                                generate_nonce_tree(rng, &unsigned_vtxo_tree, own_cosigner_pk)
-                                    .map_err(Error::from)
-                                    .context("failed to generate VTXO nonce tree")?;
+                            let nonce_tree = generate_nonce_tree(
+                                rng,
+                                &unsigned_vtxo_tree,
+                                own_cosigner_pk,
+                                &e.unsigned_round_tx,
+                            )
+                            .map_err(Error::from)
+                            .context("failed to generate VTXO nonce tree")?;
 
                             tracing::info!(
                                 cosigner_pk = %own_cosigner_pk,

--- a/ark-dlc-sample/src/main.rs
+++ b/ark-dlc-sample/src/main.rs
@@ -689,7 +689,12 @@ async fn settle(
         .unsigned_vtxo_tree
         .expect("to have an unsigned VTXO tree");
 
-    let nonce_tree = generate_nonce_tree(&mut rng, &unsigned_vtxo_tree, cosigner_kp.public_key())?;
+    let nonce_tree = generate_nonce_tree(
+        &mut rng,
+        &unsigned_vtxo_tree,
+        cosigner_kp.public_key(),
+        &round_signing_event.unsigned_round_tx,
+    )?;
 
     grpc_client
         .submit_tree_nonces(

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -404,7 +404,12 @@ async fn settle(
         .unsigned_vtxo_tree
         .expect("to have an unsigned VTXO tree");
 
-    let nonce_tree = generate_nonce_tree(&mut rng, &unsigned_vtxo_tree, cosigner_kp.public_key())?;
+    let nonce_tree = generate_nonce_tree(
+        &mut rng,
+        &unsigned_vtxo_tree,
+        cosigner_kp.public_key(),
+        &round_signing_event.unsigned_round_tx,
+    )?;
 
     grpc_client
         .submit_tree_nonces(


### PR DESCRIPTION
Our approach to nonce generation was a bit questionable since we were using the low level API `new_musig_nonce_pair`, which is easier to misuse.

I doubt it, but maybe this helps with https://github.com/ArkLabsHQ/ark-rs/issues/59.