### PR TITLE
Upgrade to Rust stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly
           targets: wasm32-unknown-unknown
           components: rustfmt
       - uses: dprint/check@v2.2
@@ -45,8 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
-      - name: Setup rust toolchain
-        run: rustup show
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -55,10 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
-      - name: Setup rust toolchain
-        run: |
-          rustup show
-          rustup target add wasm32-unknown-unknown
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Build crates for WASM
         env:
@@ -71,8 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
-      - name: Setup rust toolchain
-        run: rustup show
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Running cargo tests
         run: RUST_BACKTRACE=1 cargo test --workspace --exclude e2e-tests ark-rust-secp256k1-zkp

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -25,8 +25,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/ark-core/src/redeem.rs
+++ b/ark-core/src/redeem.rs
@@ -30,7 +30,6 @@ use std::io::Write;
 
 /// The byte value corresponds to the string "taptree".
 const VTXO_TAPROOT_KEY: [u8; 7] = [116, 97, 112, 116, 114, 101, 101];
-// const VTXO_TAPROOT_KEY: [u8; 7] = [97, 112, 116, 114, 101, 101, 0];
 
 /// A VTXO to be spent into an unconfirmed VTXO.
 #[derive(Debug, Clone)]
@@ -124,8 +123,7 @@ pub fn build_redeem_transaction(
             FeeRate::from_sat_per_kwu(253),
             vtxos.as_slice(),
             outputs.len(),
-        )
-        .map_err(Error::from)?;
+        )?;
 
         computed_fee + extra_fee
     };

--- a/ark-core/src/tx_weight_estimator.rs
+++ b/ark-core/src/tx_weight_estimator.rs
@@ -125,8 +125,10 @@ impl TxWeightEstimator {
     }
 
     /// VSize gets the estimated virtual size of the transactions, in vbytes.
+    #[allow(clippy::manual_div_ceil)]
     pub fn vsize(&self) -> usize {
         // A tx's vsize is 1/4 of the weight, rounded up.
+
         (self.weight() + 3) / 4
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.81"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
And run CI on Rust stable.

It does not really make sense for a library to set a specific Rust version with a `rust-toolchain.toml` file, so we remove it.