### PR TITLE
Feat/sync specific vtxo

### DIFF
--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -127,7 +127,6 @@ pub use error::Error;
 /// #         &self,
 /// #         server_pk: XOnlyPublicKey,
 /// #         exit_delay: bitcoin::Sequence,
-/// #         descriptor_template: &str,
 /// #         network: Network,
 /// #     ) -> Result<BoardingOutput, Error> {
 /// #         unimplemented!()

--- a/e2e-tests/tests/e2e_concurrent_boarding.rs
+++ b/e2e-tests/tests/e2e_concurrent_boarding.rs
@@ -62,20 +62,20 @@ pub async fn concurrent_boarding() {
     let alice_task = tokio::spawn({
         async move {
             let mut rng = StdRng::from_entropy();
-            alice.board(&mut rng).await.unwrap();
+            alice.settle_all(&mut rng).await.unwrap();
             alice
         }
     });
 
     let bob_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        bob.board(&mut rng).await.unwrap();
+        bob.settle_all(&mut rng).await.unwrap();
         bob
     });
 
     let claire_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        claire.board(&mut rng).await.unwrap();
+        claire.settle_all(&mut rng).await.unwrap();
         claire
     });
 
@@ -144,20 +144,20 @@ pub async fn concurrent_boarding() {
     let alice_task = tokio::spawn({
         async move {
             let mut rng = StdRng::from_entropy();
-            alice.board(&mut rng).await.unwrap();
+            alice.settle_all(&mut rng).await.unwrap();
             alice
         }
     });
 
     let bob_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        bob.board(&mut rng).await.unwrap();
+        bob.settle_all(&mut rng).await.unwrap();
         bob
     });
 
     let claire_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        claire.board(&mut rng).await.unwrap();
+        claire.settle_all(&mut rng).await.unwrap();
         claire
     });
 

--- a/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
@@ -43,7 +43,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     assert_eq!(offchain_balance.total(), Amount::ZERO);
 
-    alice.board(&mut rng).await.unwrap();
+    alice.settle_all(&mut rng).await.unwrap();
     wait_until_balance(&alice, fund_amount, Amount::ZERO).await;
 
     alice.commit_vtxos_on_chain().await.unwrap();


### PR DESCRIPTION
the original `settle` function has been replaced by 2 new functions
- `settle_all`: will attempt to settle all boarding inputs and pending vtxos
- `settle`: which accepts inputs of which boarding and pending vtxos to settle

with this clients can decide to settle all VTXOs at once or decide to settle only specific VTXOs

Note: I've cherry-picked a single e2e test to use the new functions. The other e2e tests are still using the `settle_all` function. 

Note: This is a breaking change due to renaming the existing `settle` function to `settle_all`. 